### PR TITLE
Change schema url in "composer.json" (currently 404 error)

### DIFF
--- a/src/catalog.json
+++ b/src/catalog.json
@@ -365,7 +365,7 @@
       "name": "composer.json",
       "description": "PHP Composer configuration file",
       "fileMatch": ["composer.json"],
-      "url": "https://json.schemastore.org/composer"
+      "url": "https://raw.githubusercontent.com/composer/composer/master/res/composer-schema.json"
     },
     {
       "name": "component.json",


### PR DESCRIPTION
Currently, I get a 404 error. 😭

```
[json 768] Unable to load schema from 'https://json.schemastore.org/composer': Request vscode/content failed with message: Bad response from https://json.schemastore.org/composer: 404. [W]
```

<img width="967" alt="coc-json-schema-url-error-in-composer" src="https://user-images.githubusercontent.com/188642/120485149-c59d8680-c3ee-11eb-8273-51604d485fb8.png">

---

Adjusted based on schemastore's "catalog.json".

- **REF**:
  - https://github.com/SchemaStore/schemastore/commit/5f3d36d24333a9c5c4246155e9480f456e37dc52#diff-1b8f038f5afb1158263a1fc83b9c0ca5a7438cceb90adad99d87168f70edc815


