### PR TITLE
fix(provideCompletionItem): fix res maybe null

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -141,7 +141,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
         token: CancellationToken,
         next: ProvideCompletionItemsSignature
       ): ProviderResult<CompletionItem[] | CompletionList> => {
-        return Promise.resolve(next(document, position, context, token)).then((res: CompletionItem[] | CompletionList) => {
+        return Promise.resolve(next(document, position, context, token)).then((res: CompletionItem[] | CompletionList = []) => {
           let doc = workspace.getDocument(document.uri)
           if (!doc) return []
           let items: CompletionItem[] = res.hasOwnProperty('isIncomplete') ? (res as CompletionList).items : res as CompletionItem[]


### PR DESCRIPTION
Latest coc.nvim will return null when there no complete items


```
2022-05-16T11:41:29.687 ERROR (pid:63870) [node-client] - TypeError: Cannot read property 'hasOwnProperty' of null Error
    at xA.echoError (/Users/aioiyuuko/.configrc/nvim/viml/plugins/coc.nvim/build/index.js:35:1869)
    at Sx.completeSource (/Users/aioiyuuko/.configrc/nvim/viml/plugins/coc.nvim/build/index.js:266:32983)
    at async Promise.all (index 0)
    at async Sx.completeSources (/Users/aioiyuuko/.configrc/nvim/viml/plugins/coc.nvim/build/index.js:266:31773)
    at async Sx.doComplete (/Users/aioiyuuko/.configrc/nvim/viml/plugins/coc.nvim/build/index.js:266:31244)
    at async Bee.startCompletion (/Users/aioiyuuko/.configrc/nvim/viml/plugins/coc.nvim/build/index.js:266:42932)
    at async Bee.triggerCompletion (/Users/aioiyuuko/.configrc/nvim/viml/plugins/coc.nvim/build/index.js:266:46707)
    at async Bee.onTextChangedI (/Users/aioiyuuko/.configrc/nvim/viml/plugins/coc.nvim/build/index.js:266:45350)
2022-05-16T11:41:29.687 ERROR (pid:63870) [completion-complete] - Complete error: json TypeError: Cannot read property 'hasOwnProperty' of null
    at /Users/aioiyuuko/.config/coc/extensions/node_modules/coc-json/lib/index.js:33:149815
    at async rx.doComplete (/Users/aioiyuuko/.configrc/nvim/viml/plugins/coc.nvim/build/index.js:262:9849)

```