### PR TITLE
fix: no default schema from catalog.json

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -391,7 +391,7 @@ function getSettings(): Settings {
     for (let item of catalog.schemas) {
       let { fileMatch, url } = item
       if (Array.isArray(fileMatch)) {
-        if (allFileMatches.some(s => !fileMatch.includes(s))) {
+        if (!allFileMatches.some(s => fileMatch.includes(s))) {
           settings.json!.schemas!.push({ fileMatch, url })
         }
       } else if (typeof fileMatch === 'string') {


### PR DESCRIPTION
Hi, thanks for the hard work of creating and maintaining CoC.nvim.

From the `else` branch, I guess this is what you intended to do with the `allFileMatches` variable.
I just don't understand why `allFileMatches` is an empty array.

Fixes #60.