### PR TITLE
Add repository key in the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.9.2",
   "description": "Json extension for coc.nvim",
   "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neoclide/coc-json.git"
+  },
   "publisher": "chemzqm",
   "keywords": [
     "coc.nvim",


### PR DESCRIPTION
It helps security tools[1] to scan the package and avoids the following
error:
Source code issue: Repository reference not found

[1] https://www.adyen.com/knowledge-hub/skantek-securing-nodejs-at-adyen
