### PR TITLE
Sync package-lock.json and check it in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: ['20', '22', '23']
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'npm'
+
+      - run: npm install --frozen-lockfile
+      - run: git diff --exit-code package-lock.json
+      - run: npx tsc --noEmit

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coc-json",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coc-json",
-      "version": "1.9.2",
+      "version": "1.9.3",
       "license": "MIT",
       "devDependencies": {
         "@chemzqm/tsconfig": "^0.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "esbuild": "^0.25.0",
         "jsonc-parser": "^3.2.0",
         "request-light": "^0.7.0",
-        "typescript": "^4.1.3",
+        "typescript": "^5.8.3",
         "vscode-json-languageservice": "^5.4.3",
         "vscode-languageserver": "^8.1.0",
         "vscode-languageserver-protocol": "^3.17.3",
@@ -544,9 +544,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -554,7 +554,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/vscode-json-languageservice": {

--- a/package.json
+++ b/package.json
@@ -154,11 +154,10 @@
     "esbuild": "^0.25.0",
     "jsonc-parser": "^3.2.0",
     "request-light": "^0.7.0",
-    "typescript": "^4.1.3",
+    "typescript": "^5.8.3",
     "vscode-json-languageservice": "^5.4.3",
     "vscode-languageserver": "^8.1.0",
     "vscode-languageserver-protocol": "^3.17.3",
     "vscode-uri": "^3.0.7"
-  },
-  "dependencies": {}
+  }
 }


### PR DESCRIPTION
At the moment, `package-lock.json` is not in sync with `package.json` so `npm install` always updates the former. This PR syncs the files and creates a basic CI workflow that checks that the file is up to date.

I also included typechecking in the CI workflow which required me to update typescript.